### PR TITLE
在庫管理機能の実装とVavrの導入

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,13 +33,16 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	// MyBatis Plus - Spring Boot 4対応版
 	implementation 'com.baomidou:mybatis-plus-spring-boot4-starter:3.5.15'
+	// MyBatis Plus - ページングプラグイン用（v3.5.9以降必須）
+	// PaginationInnerInterceptorを使用するために必要
+	implementation 'com.baomidou:mybatis-plus-jsqlparser:3.5.15'
 	implementation 'com.baomidou:mybatis-plus-extension:3.5.15'
 	implementation 'com.baomidou:mybatis-plus-generator:3.5.15'
-	// MyBatis Plus - ページングプラグイン用（v3.5.9以降必須）
-	implementation 'com.baomidou:mybatis-plus-jsqlparser:3.5.15'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
 	// SpringDoc OpenAPI (Swagger UI)
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.15'
+	// Vavr
+	implementation 'io.vavr:vavr:0.10.4'
 
 	// .envファイル読み込み
 	developmentOnly 'me.paulschwarz:springboot4-dotenv:5.1.0'

--- a/src/main/java/com/playjava/controller/MStockController.java
+++ b/src/main/java/com/playjava/controller/MStockController.java
@@ -1,0 +1,182 @@
+package com.playjava.controller;
+
+import org.springframework.web.bind.annotation.RestController;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.playjava.service.impl.MStockServiceImpl;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestBody;
+import jakarta.validation.Valid;
+
+import com.playjava.entity.MStock;
+import com.playjava.context.UserContext;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@RestController
+@RequestMapping("/api/v1/stocks")
+@Tag(name = "在庫管理", description = "在庫マスタのCRUD操作と在庫検索API")
+public class MStockController {
+
+    private final Logger log = LoggerFactory.getLogger(MStockController.class);
+
+    @Autowired
+    private MStockServiceImpl mStockService;
+
+    // 在庫登録
+    @Operation(
+        summary = "在庫登録",
+        description = "新規在庫を登録します。在庫IDは自動生成されます。"
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "登録成功"),
+        @ApiResponse(responseCode = "400", description = "バリデーションエラー", content = @Content(schema = @Schema(implementation = String.class)))
+    })
+    @PostMapping
+    public void createStock(
+            @Parameter(description = "登録する在庫情報", required = true)
+            @Valid @RequestBody MStock stock) {
+        log.info("createStock: stock={}", stock);
+        
+        try {
+            // 在庫登録処理（内部でUserContextが設定される）
+            mStockService.createStockImpl(stock);
+        } finally {
+            // リクエスト完了後、コンテキストをクリア
+            UserContext.clear();
+        }
+    }
+
+    // 在庫更新
+    @Operation(
+        summary = "在庫更新",
+        description = "既存在庫の情報を更新します。"
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "更新成功"),
+        @ApiResponse(responseCode = "400", description = "バリデーションエラー"),
+        @ApiResponse(responseCode = "404", description = "在庫が見つかりません")
+    })
+    @PutMapping("/updateStock")
+    public void updateStock(
+            @Parameter(description = "更新する在庫情報", required = true)
+            @Valid @RequestBody MStock stock) {
+        log.info("updateStock: stock={}", stock);
+        
+        try {
+            // 更新者をコンテキストに設定
+            UserContext.setCurrentUserId(stock.getStockId());
+            
+            // 在庫更新処理
+            mStockService.updateStockImpl(stock);
+        } finally {
+            // リクエスト完了後、コンテキストをクリア
+            UserContext.clear();
+        }
+    }
+
+    // 在庫論理削除
+    @Operation(
+        summary = "在庫削除",
+        description = "指定された在庫を論理削除します。"
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "削除成功"),
+        @ApiResponse(responseCode = "404", description = "在庫が見つかりません")
+    })
+    @DeleteMapping("/deleteStock/{stockId}")
+    public void deleteStock(
+            @Parameter(description = "削除する在庫のID", required = true, example = "550e8400-e29b-41d4-a716-446655440000")
+            @PathVariable String stockId) {
+        log.info("deleteStock: stockId={}", stockId);
+        
+        try {
+            // 削除者をコンテキストに設定
+            UserContext.setCurrentUserId(stockId);
+            
+            // 在庫論理削除処理
+            mStockService.deleteStockImpl(stockId);
+        } finally {
+            // リクエスト完了後、コンテキストをクリア
+            UserContext.clear();
+        }
+    }
+
+    // 在庫一覧（ページング・ソート対応）
+    @Operation(
+        summary = "在庫検索（ページング対応）",
+        description = "在庫を条件で検索し、ページング・ソート機能を提供します。"
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "検索成功")
+    })
+    @GetMapping("/search")
+    public IPage<MStock> searchStock(
+            @Parameter(description = "商品ID（完全一致）", example = "550e8400-e29b-41d4-a716-446655440000")
+            @RequestParam(required = false) String productId,
+            @Parameter(description = "商品名（部分一致）", example = "商品名")
+            @RequestParam(required = false) String productName,
+            @Parameter(description = "在庫数量最小値（以上）", example = "0")
+            @RequestParam(required = false) Integer quantityMin,
+            @Parameter(description = "在庫数量最大値（以下）", example = "100")
+            @RequestParam(required = false) Integer quantityMax,
+            @Parameter(description = "在庫ステータス（0=在庫あり、1=在庫なし、2=発注済み）", example = "0")
+            @RequestParam(required = false) Integer status,
+            @Parameter(description = "削除フラグ", example = "false")
+            @RequestParam(required = false) Boolean deleteFlag,
+            @Parameter(description = "ページ番号（1から開始）", example = "1")
+            @RequestParam(defaultValue = "1") int pageNum,
+            @Parameter(description = "1ページあたりの件数", example = "10")
+            @RequestParam(defaultValue = "10") int pageSize,
+            @Parameter(description = "ソート対象フィールド", example = "updateDate")
+            @RequestParam(defaultValue = "updateDate") String sortBy,
+            @Parameter(description = "ソート順序（asc/desc）", example = "desc")
+            @RequestParam(defaultValue = "desc") String sortOrder) {
+
+        log.info("searchStock: productId={}, productName={}, quantityMin={}, quantityMax={}, status={}, deleteFlag={}, pageNum={}, pageSize={}, sortBy={}, sortOrder={}",
+                productId, productName, quantityMin, quantityMax, status, deleteFlag, pageNum, pageSize, sortBy, sortOrder);
+
+        return mStockService.searchStockImpl(
+                productId, productName, quantityMin, quantityMax, status, deleteFlag,
+                pageNum, pageSize, sortBy, sortOrder);
+    }
+
+    // 在庫照会（商品ID指定）
+    @Operation(
+        summary = "在庫照会（商品ID指定）",
+        description = "指定された商品IDの在庫情報を取得します。"
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "照会成功"),
+        @ApiResponse(responseCode = "404", description = "在庫が見つかりません")
+    })
+    @GetMapping("/products/{productId}")
+    public MStock getStockByProductId(
+            @Parameter(description = "照会する商品ID", required = true, example = "550e8400-e29b-41d4-a716-446655440000")
+            @PathVariable String productId) {
+        log.info("getStockByProductId: productId={}", productId);
+        
+        try {
+            // 在庫照会処理
+            return mStockService.getStockByProductIdImpl(productId);
+        } finally {
+            // リクエスト完了後、コンテキストをクリア
+            UserContext.clear();
+        }
+    }
+}

--- a/src/main/java/com/playjava/mapper/MProductMapper.java
+++ b/src/main/java/com/playjava/mapper/MProductMapper.java
@@ -1,0 +1,11 @@
+package com.playjava.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+
+import com.playjava.entity.MProduct;
+
+@Mapper
+public interface MProductMapper extends BaseMapper<MProduct>{
+  
+}

--- a/src/main/java/com/playjava/mapper/MStockMapper.java
+++ b/src/main/java/com/playjava/mapper/MStockMapper.java
@@ -1,0 +1,11 @@
+package com.playjava.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+
+import com.playjava.entity.MStock;
+
+@Mapper
+public interface MStockMapper extends BaseMapper<MStock>{
+  
+}

--- a/src/main/java/com/playjava/service/adapter/MStockService.java
+++ b/src/main/java/com/playjava/service/adapter/MStockService.java
@@ -1,0 +1,8 @@
+package com.playjava.service.adapter;
+
+import com.baomidou.mybatisplus.extension.service.IService;
+import com.playjava.entity.MStock;
+
+public interface MStockService extends IService<MStock>{
+    
+}

--- a/src/main/java/com/playjava/service/impl/MStockServiceImpl.java
+++ b/src/main/java/com/playjava/service/impl/MStockServiceImpl.java
@@ -1,0 +1,312 @@
+package com.playjava.service.impl;
+
+import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.playjava.mapper.MStockMapper;
+import com.playjava.mapper.MProductMapper;
+import com.playjava.entity.MStock;
+import com.playjava.entity.MProduct;
+import com.playjava.service.adapter.MStockService;
+import com.playjava.handler.UuidFactory;
+import com.playjava.context.UserContext;
+
+import java.util.UUID;
+import java.time.OffsetDateTime;
+
+import io.vavr.control.Option;
+
+@Service
+public class MStockServiceImpl extends ServiceImpl<MStockMapper, MStock> implements MStockService {
+
+    @Autowired
+    private MProductMapper mProductMapper;
+
+    /**
+     * 在庫登録処理
+     * @param stock UIから@RequestBodyで受け取った在庫情報
+     * @return 作成成功の場合true
+     */
+    public boolean createStockImpl(MStock stock) {
+        // 業務ロジック: バリデーションと変換をVavrで処理
+        
+        // 商品マスタの存在チェック（MyBatis呼び出し - 副作用あり、一括処理）
+        MProduct product = mProductMapper.selectById(stock.getProductId());
+        
+        // 商品マスタの存在チェック（Option使用）
+        Option.of(product)
+            .getOrElseThrow(() -> new RuntimeException("商品が存在しません: productId=" + stock.getProductId()));
+        
+        // 一意性チェック（MyBatis呼び出し - 副作用あり、一括処理）
+        LambdaQueryWrapper<MStock> wrapper = new LambdaQueryWrapper<>();
+        wrapper.eq(MStock::getProductId, stock.getProductId());
+        long count = this.count(wrapper);
+        
+        if (count > 0) {
+            throw new RuntimeException("この商品の在庫レコードは既に存在します。更新APIを使用してください: productId=" + stock.getProductId());
+        }
+        
+        // 業務ロジック: UUID生成と設定
+        UUID stockId = UuidFactory.newUuid();
+        stock.setStockId(stockId.toString());
+
+        // 業務ロジック: quantityのバリデーション（Option使用）
+        Integer quantity = Option.of(stock.getQuantity())
+            .filter(q -> q >= 0)
+            .getOrElseThrow(() -> new RuntimeException("在庫数量は0以上の整数である必要があります: quantity=" + stock.getQuantity()));
+        
+        // 業務ロジック: statusの自動設定（Option使用）
+        Integer status = Option.of(stock.getStatus())
+            .map(s -> {
+                // statusのバリデーション（0-2の範囲）
+                if (s < 0 || s > 2) {
+                    throw new RuntimeException("在庫ステータスは0（在庫あり）、1（在庫なし）、2（発注済み）のいずれかである必要があります: status=" + s);
+                }
+                return s;
+            })
+            .getOrElse(() -> quantity > 0 ? 0 : 1); // 在庫あり: 0, 在庫なし: 1
+        
+        stock.setStatus(status);
+        stock.setDeleteFlag(false);
+
+        // MyBatis呼び出し - 副作用あり（一括処理）
+        return this.save(stock);
+    }
+
+    /**
+     * 在庫検索処理（ページング・ソート対応）
+     * @param productId 商品ID（完全一致）
+     * @param productName 商品名（部分一致、商品マスタとJOIN）
+     * @param quantityMin 在庫数量最小値（以上）
+     * @param quantityMax 在庫数量最大値（以下）
+     * @param status 在庫ステータス（完全一致、0=在庫あり、1=在庫なし、2=発注済み）
+     * @param deleteFlag 削除フラグ（true/false/null、未指定時はfalseのみ）
+     * @param pageNum ページ番号（1から開始）
+     * @param pageSize ページサイズ
+     * @param sortBy ソート対象カラム（stockId, productId, quantity, status, createDate, updateDate）
+     * @param sortOrder ソート順（asc/desc）
+     * @return ページング情報を含む検索結果
+     */
+    public IPage<MStock> searchStockImpl(
+            String productId,
+            String productName,
+            Integer quantityMin,
+            Integer quantityMax,
+            Integer status,
+            Boolean deleteFlag,
+            int pageNum,
+            int pageSize,
+            String sortBy,
+            String sortOrder) {
+
+        Page<MStock> page = new Page<>(pageNum, pageSize);
+        LambdaQueryWrapper<MStock> wrapper = buildSearchWrapper(
+                productId, productName, quantityMin, quantityMax, status, deleteFlag);
+
+        // ソート設定
+        boolean asc = "asc".equalsIgnoreCase(sortOrder);
+        if (asc) {
+            switch (sortBy) {
+                case "stockId":
+                    wrapper.orderByAsc(MStock::getStockId);
+                    break;
+                case "productId":
+                    wrapper.orderByAsc(MStock::getProductId);
+                    break;
+                case "quantity":
+                    wrapper.orderByAsc(MStock::getQuantity);
+                    break;
+                case "status":
+                    wrapper.orderByAsc(MStock::getStatus);
+                    break;
+            }
+        } else {
+            switch (sortBy) {
+                case "stockId":
+                    wrapper.orderByDesc(MStock::getStockId);
+                    break;
+                case "productId":
+                    wrapper.orderByDesc(MStock::getProductId);
+                    break;
+                case "quantity":
+                    wrapper.orderByDesc(MStock::getQuantity);
+                    break;
+                case "status":
+                    wrapper.orderByDesc(MStock::getStatus);
+                    break;
+            }
+        }
+
+        return this.page(page, wrapper);
+    }
+
+    /**
+     * 在庫検索条件の共通Wrapper生成
+     * 注意: 商品名による検索はJOINが必要なため、現時点ではproductIdのみで検索する
+     * TODO: 商品マスタとJOINして商品名での検索を実装する
+     */
+    private LambdaQueryWrapper<MStock> buildSearchWrapper(
+            String productId,
+            String productName,
+            Integer quantityMin,
+            Integer quantityMax,
+            Integer status,
+            Boolean deleteFlag) {
+
+        LambdaQueryWrapper<MStock> wrapper = new LambdaQueryWrapper<>();
+
+        // 商品ID（完全一致）
+        if (productId != null && !productId.isEmpty()) {
+            wrapper.eq(MStock::getProductId, productId);
+        }
+
+        // 商品名（部分一致）は商品マスタとJOINが必要なため、現時点では未実装
+        // TODO: 商品マスタとJOINして商品名での検索を実装する
+        if (productName != null && !productName.isEmpty()) {
+            // 商品名で商品IDを取得してから在庫を検索する必要がある
+            // 簡易実装として、productIdで検索する（商品名検索は別途実装が必要）
+        }
+
+        // 在庫数量最小値（以上）
+        if (quantityMin != null) {
+            wrapper.ge(MStock::getQuantity, quantityMin);
+        }
+
+        // 在庫数量最大値（以下）
+        if (quantityMax != null) {
+            wrapper.le(MStock::getQuantity, quantityMax);
+        }
+
+        // 在庫ステータス（完全一致）
+        if (status != null) {
+            wrapper.eq(MStock::getStatus, status);
+        }
+
+        // 削除フラグ（未指定時はfalseのみ、明示的に指定した場合のみ削除済みも含める）
+        if (deleteFlag != null) {
+            wrapper.eq(MStock::getDeleteFlag, deleteFlag);
+        } else {
+            wrapper.eq(MStock::getDeleteFlag, false);
+        }
+
+        return wrapper;
+    }
+
+    /**
+     * 在庫照会処理（商品ID指定）
+     * @param productId 商品ID
+     * @return 在庫情報
+     */
+    public MStock getStockByProductIdImpl(String productId) {
+        // 業務ロジック: バリデーションをVavrで処理
+        
+        // 商品マスタの存在チェック（MyBatis呼び出し - 副作用あり、一括処理）
+        MProduct product = mProductMapper.selectById(productId);
+        
+        // 商品マスタの存在チェック（Option使用）
+        Option.of(product)
+            .getOrElseThrow(() -> new RuntimeException("商品が存在しません: productId=" + productId));
+
+        // 商品IDで在庫を検索（MyBatis呼び出し - 副作用あり、一括処理）
+        LambdaQueryWrapper<MStock> wrapper = new LambdaQueryWrapper<>();
+        wrapper.eq(MStock::getProductId, productId);
+        // 削除済みも含めて取得（在庫照会のため）
+        // 論理削除フラグは@TableLogicにより自動的に除外されるため、明示的に指定しない
+        
+        MStock stock = this.getOne(wrapper);
+        
+        // 在庫レコードの存在チェック（Option使用）
+        return Option.of(stock)
+            .getOrElseThrow(() -> new RuntimeException("在庫レコードが存在しません。在庫登録を行ってください: productId=" + productId));
+    }
+
+    /**
+     * 在庫更新処理
+     * @param stock UIから@RequestBodyで受け取った在庫情報
+     * @return 更新成功の場合true
+     */
+    public boolean updateStockImpl(MStock stock) {
+        try {
+            // 業務ロジック: バリデーションをVavrで処理
+            String updateUser = UserContext.getCurrentUserId();
+
+            // 在庫IDのバリデーション（Option使用）
+            String stockId = Option.of(stock.getStockId())
+                .filter(id -> !id.isEmpty())
+                .getOrElseThrow(() -> new RuntimeException("在庫IDは必須です: stockId=" + stock.getStockId()));
+
+            // 既存の在庫レコードを取得（MyBatis呼び出し - 副作用あり、一括処理）
+            MStock existingStock = this.getById(stockId);
+            
+            // 在庫レコードの存在チェック（Option使用）
+            Option.of(existingStock)
+                .getOrElseThrow(() -> new RuntimeException("在庫レコードが存在しません: stockId=" + stockId));
+            
+            // 商品マスタの存在チェック（productIdが変更される場合）
+            Option.of(stock.getProductId())
+                .filter(productId -> !productId.equals(existingStock.getProductId()))
+                .forEach(productId -> {
+                    // MyBatis呼び出し - 副作用あり、一括処理
+                    MProduct product = mProductMapper.selectById(productId);
+                    Option.of(product)
+                        .getOrElseThrow(() -> new RuntimeException("商品が存在しません: productId=" + productId));
+                });
+            
+            // 業務ロジック: quantityのバリデーション（Option使用）
+            Option.of(stock.getQuantity())
+                .filter(q -> q < 0)
+                .forEach(q -> {
+                    throw new RuntimeException("在庫数量は0以上の整数である必要があります: quantity=" + q);
+                });
+            
+            // 業務ロジック: statusの自動設定（Option使用）
+            Integer status = Option.of(stock.getStatus())
+                .map(s -> {
+                    // statusのバリデーション（0-2の範囲）
+                    if (s < 0 || s > 2) {
+                        throw new RuntimeException("在庫ステータスは0（在庫あり）、1（在庫なし）、2（発注済み）のいずれかである必要があります: status=" + s);
+                    }
+                    return s;
+                })
+                .getOrElse(() -> {
+                    Integer quantity = stock.getQuantity();
+                    return quantity != null && quantity > 0 ? 0 : 1; // 在庫あり: 0, 在庫なし: 1
+                });
+            
+            stock.setStatus(status);
+
+            // 更新内容を設定
+            stock.setUpdateUser(updateUser);
+            stock.setUpdateDate(OffsetDateTime.now());
+
+            // MyBatis呼び出し - 副作用あり（一括処理）
+            return this.updateById(stock);
+        } catch (Exception e) {
+            // エラー時はコンテキストをクリア
+            UserContext.clear();
+            throw e;
+        }
+    }
+
+    /**
+     * 在庫論理削除処理
+     * @param stockId 削除対象の在庫ID
+     * @return 削除成功の場合true
+     */
+    public boolean deleteStockImpl(String stockId) {
+        try {
+            // MyBatis呼び出し - 副作用あり（一括処理）
+            // MyBatis Plusの論理削除機能を使用
+            // removeByIdを使うと、@TableLogicの設定に従って自動的にdeleteFlag=trueに更新される
+            return this.removeById(stockId);
+        } catch (Exception e) {
+            // エラー時はコンテキストをクリア
+            UserContext.clear();
+            throw e;
+        }
+    }
+}

--- a/src/main/java/com/playjava/service/impl/MUserServiceImpl.java
+++ b/src/main/java/com/playjava/service/impl/MUserServiceImpl.java
@@ -19,6 +19,8 @@ import java.util.UUID;
 import java.util.List;
 import java.time.OffsetDateTime;
 
+import io.vavr.control.Option;
+
 @Service
 @RequiredArgsConstructor
 public class MUserServiceImpl extends ServiceImpl<MUserMapper, MUser> implements MUserService {
@@ -192,11 +194,12 @@ public class MUserServiceImpl extends ServiceImpl<MUserMapper, MUser> implements
         LambdaQueryWrapper<MUser> wrapper = new LambdaQueryWrapper<>();
         wrapper.eq(MUser::getUserName, userName);
         
-        // 更新時は自分自身を除外
-        if (excludeUserId != null && !excludeUserId.isEmpty()) {
-            wrapper.ne(MUser::getUserId, excludeUserId);
-        }
+        // 業務ロジック: 更新時は自分自身を除外（Option使用）
+        Option.of(excludeUserId)
+            .filter(id -> !id.isEmpty())
+            .forEach(id -> wrapper.ne(MUser::getUserId, id));
         
+        // MyBatis呼び出し - 副作用あり（一括処理）
         return this.count(wrapper) > 0;
     }
 

--- a/src/test/java/com/playjava/controller/MStockControllerTest.java
+++ b/src/test/java/com/playjava/controller/MStockControllerTest.java
@@ -1,0 +1,259 @@
+package com.playjava.controller;
+
+import com.playjava.context.UserContext;
+import com.playjava.entity.MProduct;
+import com.playjava.entity.MStock;
+import com.playjava.mapper.MProductMapper;
+import com.playjava.service.impl.MStockServiceImpl;
+import com.playjava.valueobject.SystemUser;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+@DisplayName("MStockController テスト")
+class MStockControllerTest {
+
+    @Autowired
+    private MStockController mStockController;
+
+    @Autowired
+    private MStockServiceImpl mStockService;
+
+    @Autowired
+    private MProductMapper mProductMapper;
+
+    @BeforeEach
+    void setUp() {
+        // 各テストの前にUserContextをクリア
+        UserContext.clear();
+        UserContext.setCurrentUserId(SystemUser.BOOTSTRAP);
+    }
+
+    @AfterEach
+    void tearDown() {
+        // 各テストの後にUserContextをクリア
+        UserContext.clear();
+    }
+
+    /**
+     * テスト用の商品を作成するヘルパーメソッド
+     */
+    private MProduct createTestProduct() {
+        MProduct product = new MProduct();
+        product.setProductNumber("CTRL001");
+        product.setProductName("コントローラーテスト商品");
+        product.setDescription("コントローラーテスト用の商品です");
+        product.setPrice(2000);
+        product.setCategory(1);
+        product.setDeleteFlag(false);
+        mProductMapper.insert(product);
+        return product;
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/stocks - 在庫登録が成功すること")
+    void testCreateStock_Success() {
+        // Given: テスト商品を作成
+        MProduct product = createTestProduct();
+        
+        // 在庫情報を準備
+        MStock stock = new MStock();
+        stock.setProductId(product.getProductId());
+        stock.setQuantity(150);
+        stock.setStatus(0);
+
+        // When: コントローラーを直接呼び出し
+        assertDoesNotThrow(() -> mStockController.createStock(stock), 
+            "在庫登録が例外をスローしないこと");
+        
+        // Then: 在庫IDが設定されていること
+        assertNotNull(stock.getStockId(), "stockIdが設定されていること");
+        assertEquals(product.getProductId(), stock.getProductId(), "productIdが正しく設定されていること");
+    }
+
+    @Test
+    @DisplayName("リクエスト完了後にUserContextがクリアされること")
+    void testCreateStock_ClearUserContext() {
+        // Given: テスト商品を作成
+        MProduct product = createTestProduct();
+        
+        // 在庫情報を準備
+        MStock stock = new MStock();
+        stock.setProductId(product.getProductId());
+        stock.setQuantity(100);
+        stock.setStatus(0);
+
+        // When: コントローラーを呼び出す
+        mStockController.createStock(stock);
+
+        // Then: リクエスト完了後、UserContextがクリアされていること
+        String currentUserId = UserContext.getCurrentUserId();
+        assertEquals(SystemUser.ANONYMOUS, currentUserId,
+            "リクエスト完了後、UserContextがクリアされてANONYMOUSが返ること");
+    }
+
+    @Test
+    @DisplayName("PUT /api/v1/stocks/updateStock - 在庫更新が成功すること")
+    void testUpdateStock_Success() {
+        // Given: テスト商品と在庫を作成
+        MProduct product = createTestProduct();
+        MStock stock = new MStock();
+        stock.setProductId(product.getProductId());
+        stock.setQuantity(100);
+        stock.setStatus(0);
+        mStockService.createStockImpl(stock);
+
+        // 在庫情報を更新
+        stock.setQuantity(200);
+        stock.setStatus(0);
+
+        // When: コントローラーを呼び出す
+        assertDoesNotThrow(() -> mStockController.updateStock(stock), 
+            "在庫更新が例外をスローしないこと");
+
+        // Then: 更新後の値を確認
+        MStock updatedStock = mStockService.getById(stock.getStockId());
+        assertEquals(200, updatedStock.getQuantity(), "quantityが更新されていること");
+    }
+
+    @Test
+    @DisplayName("DELETE /api/v1/stocks/deleteStock/{stockId} - 在庫削除が成功すること")
+    void testDeleteStock_Success() {
+        // Given: テスト商品と在庫を作成
+        MProduct product = createTestProduct();
+        MStock stock = new MStock();
+        stock.setProductId(product.getProductId());
+        stock.setQuantity(100);
+        stock.setStatus(0);
+        mStockService.createStockImpl(stock);
+        String stockId = stock.getStockId();
+
+        // When: コントローラーを呼び出す
+        assertDoesNotThrow(() -> mStockController.deleteStock(stockId), 
+            "在庫削除が例外をスローしないこと");
+
+        // Then: 削除後の在庫が取得できないこと（論理削除）
+        MStock deletedStock = mStockService.getById(stockId);
+        assertNull(deletedStock, "削除後の在庫が取得できないこと");
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/stocks/search - 在庫検索が成功すること")
+    void testSearchStock_Success() {
+        // Given: テスト商品と在庫を作成
+        MProduct product = createTestProduct();
+        MStock stock = new MStock();
+        stock.setProductId(product.getProductId());
+        stock.setQuantity(100);
+        stock.setStatus(0);
+        mStockService.createStockImpl(stock);
+
+        // When: コントローラーを呼び出す
+        IPage<MStock> result = mStockController.searchStock(
+            product.getProductId(), null, null, null, null, null, 1, 10, "updateDate", "desc");
+
+        // Then: 検索結果が取得できること
+        assertNotNull(result, "検索結果が取得できること");
+        assertTrue(result.getTotal() > 0, "検索結果が1件以上あること");
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/stocks/search - ページングが正しく動作すること")
+    void testSearchStock_Pagination() {
+        // Given: 複数のテスト商品と在庫を作成
+        for (int i = 0; i < 15; i++) {
+            MProduct product = new MProduct();
+            product.setProductNumber("PAGE" + String.format("%03d", i));
+            product.setProductName("ページングテスト商品" + i);
+            product.setDescription("ページングテスト用");
+            product.setPrice(1000 + i);
+            product.setCategory(1);
+            product.setDeleteFlag(false);
+            mProductMapper.insert(product);
+
+            MStock stock = new MStock();
+            stock.setProductId(product.getProductId());
+            stock.setQuantity(100 + i);
+            stock.setStatus(0);
+            mStockService.createStockImpl(stock);
+        }
+
+        // When: 1ページ目を取得（ページサイズ10）
+        IPage<MStock> page1 = mStockController.searchStock(
+            null, null, null, null, null, null, 1, 10, "updateDate", "desc");
+
+        // Then: ページングが正しく動作すること
+        assertNotNull(page1, "検索結果が取得できること");
+        assertEquals(10, page1.getRecords().size(), "1ページ目の件数が10件であること");
+        assertTrue(page1.getTotal() >= 15, "総件数が15件以上であること");
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/stocks/products/{productId} - 在庫照会が成功すること")
+    void testGetStockByProductId_Success() {
+        // Given: テスト商品と在庫を作成
+        MProduct product = createTestProduct();
+        MStock stock = new MStock();
+        stock.setProductId(product.getProductId());
+        stock.setQuantity(100);
+        stock.setStatus(0);
+        mStockService.createStockImpl(stock);
+
+        // When: コントローラーを呼び出す
+        MStock foundStock = mStockController.getStockByProductId(product.getProductId());
+
+        // Then: 在庫情報が正しく取得できること
+        assertNotNull(foundStock, "在庫情報が取得できること");
+        assertEquals(product.getProductId(), foundStock.getProductId(), "productIdが正しいこと");
+        assertEquals(100, foundStock.getQuantity(), "quantityが正しいこと");
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/stocks/search - ソートが正しく動作すること")
+    void testSearchStock_Sort() {
+        // Given: 複数のテスト商品と在庫を作成
+        for (int i = 0; i < 5; i++) {
+            MProduct product = new MProduct();
+            product.setProductNumber("SORT" + String.format("%03d", i));
+            product.setProductName("ソートテスト商品" + i);
+            product.setDescription("ソートテスト用");
+            product.setPrice(1000);
+            product.setCategory(1);
+            product.setDeleteFlag(false);
+            mProductMapper.insert(product);
+
+            MStock stock = new MStock();
+            stock.setProductId(product.getProductId());
+            stock.setQuantity(100 + i * 10); // quantityを異なる値に設定
+            stock.setStatus(0);
+            mStockService.createStockImpl(stock);
+        }
+
+        // When: quantityで昇順ソート
+        IPage<MStock> ascResult = mStockController.searchStock(
+            null, null, null, null, null, null, 1, 10, "quantity", "asc");
+
+        // Then: ソートが正しく動作すること
+        assertNotNull(ascResult, "検索結果が取得できること");
+        assertTrue(ascResult.getRecords().size() > 0, "検索結果が1件以上あること");
+        
+        // quantityが昇順になっていることを確認
+        if (ascResult.getRecords().size() > 1) {
+            for (int i = 0; i < ascResult.getRecords().size() - 1; i++) {
+                Integer current = ascResult.getRecords().get(i).getQuantity();
+                Integer next = ascResult.getRecords().get(i + 1).getQuantity();
+                assertTrue(current <= next, 
+                    String.format("quantityが昇順になっていること: %d <= %d", current, next));
+            }
+        }
+    }
+}

--- a/src/test/java/com/playjava/service/MStockServiceImplTest.java
+++ b/src/test/java/com/playjava/service/MStockServiceImplTest.java
@@ -1,0 +1,379 @@
+package com.playjava.service;
+
+import com.playjava.context.UserContext;
+import com.playjava.entity.MProduct;
+import com.playjava.entity.MStock;
+import com.playjava.mapper.MProductMapper;
+import com.playjava.service.impl.MStockServiceImpl;
+import com.playjava.valueobject.SystemUser;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional // テスト後にロールバック
+@DisplayName("MStockServiceImpl テスト")
+class MStockServiceImplTest {
+
+    @Autowired
+    private MStockServiceImpl mStockService;
+
+    @Autowired
+    private MProductMapper mProductMapper;
+
+    @BeforeEach
+    void setUp() {
+        // 各テストの前にUserContextをクリア
+        UserContext.clear();
+        UserContext.setCurrentUserId(SystemUser.BOOTSTRAP);
+    }
+
+    @AfterEach
+    void tearDown() {
+        // 各テストの後にUserContextをクリア
+        UserContext.clear();
+    }
+
+    /**
+     * テスト用の商品を作成するヘルパーメソッド
+     */
+    private MProduct createTestProduct() {
+        MProduct product = new MProduct();
+        product.setProductNumber("TEST001");
+        product.setProductName("テスト商品");
+        product.setDescription("テスト用の商品です");
+        product.setPrice(1000);
+        product.setCategory(1);
+        product.setDeleteFlag(false);
+        mProductMapper.insert(product);
+        return product;
+    }
+
+    @Test
+    @DisplayName("在庫登録が成功すること")
+    void testCreateStock_Success() {
+        // Given: テスト商品を作成
+        MProduct product = createTestProduct();
+        
+        // 在庫情報を準備
+        MStock stock = new MStock();
+        stock.setProductId(product.getProductId());
+        stock.setQuantity(100);
+        stock.setStatus(0);
+
+        // When: 在庫を登録
+        boolean result = mStockService.createStockImpl(stock);
+
+        // Then: 登録が成功すること
+        assertTrue(result, "在庫登録が成功すること");
+        assertNotNull(stock.getStockId(), "stockIdが設定されていること");
+        assertEquals(product.getProductId(), stock.getProductId(), "productIdが正しく設定されていること");
+        assertEquals(100, stock.getQuantity(), "quantityが正しく設定されていること");
+        assertEquals(0, stock.getStatus(), "statusが正しく設定されていること");
+        assertFalse(stock.getDeleteFlag(), "削除フラグがfalseであること");
+    }
+
+    @Test
+    @DisplayName("statusがnullの場合、quantityに基づいて自動設定されること")
+    void testCreateStock_AutoSetStatus() {
+        // Given: テスト商品を作成
+        MProduct product = createTestProduct();
+        
+        // 在庫情報を準備（statusをnullに設定）
+        MStock stock = new MStock();
+        stock.setProductId(product.getProductId());
+        stock.setQuantity(50);
+        stock.setStatus(null); // statusをnullに設定
+
+        // When: 在庫を登録
+        mStockService.createStockImpl(stock);
+
+        // Then: statusが自動設定されていること（quantity > 0 なので 0 = 在庫あり）
+        assertNotNull(stock.getStatus(), "statusが設定されていること");
+        assertEquals(0, stock.getStatus(), "quantity > 0 の場合、statusが0（在庫あり）になること");
+    }
+
+    @Test
+    @DisplayName("quantityが0の場合、statusが1（在庫なし）に自動設定されること")
+    void testCreateStock_AutoSetStatusZero() {
+        // Given: テスト商品を作成
+        MProduct product = createTestProduct();
+        
+        // 在庫情報を準備（quantity=0, status=null）
+        MStock stock = new MStock();
+        stock.setProductId(product.getProductId());
+        stock.setQuantity(0);
+        stock.setStatus(null);
+
+        // When: 在庫を登録
+        mStockService.createStockImpl(stock);
+
+        // Then: statusが1（在庫なし）に設定されていること
+        assertEquals(1, stock.getStatus(), "quantity = 0 の場合、statusが1（在庫なし）になること");
+    }
+
+    @Test
+    @DisplayName("商品が存在しない場合、例外がスローされること")
+    void testCreateStock_ProductNotFound() {
+        // Given: 存在しない商品IDを指定
+        MStock stock = new MStock();
+        stock.setProductId("non-existent-product-id");
+        stock.setQuantity(100);
+        stock.setStatus(0);
+
+        // When/Then: 例外がスローされること
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+            mStockService.createStockImpl(stock);
+        }, "商品が存在しない場合、例外がスローされること");
+        
+        assertTrue(exception.getMessage().contains("商品が存在しません"), 
+            "エラーメッセージに「商品が存在しません」が含まれること");
+    }
+
+    @Test
+    @DisplayName("既に在庫レコードが存在する場合、例外がスローされること")
+    void testCreateStock_DuplicateStock() {
+        // Given: テスト商品を作成し、在庫を登録
+        MProduct product = createTestProduct();
+        MStock firstStock = new MStock();
+        firstStock.setProductId(product.getProductId());
+        firstStock.setQuantity(100);
+        firstStock.setStatus(0);
+        mStockService.createStockImpl(firstStock);
+
+        // 同じ商品IDで在庫を登録しようとする
+        MStock secondStock = new MStock();
+        secondStock.setProductId(product.getProductId());
+        secondStock.setQuantity(200);
+        secondStock.setStatus(0);
+
+        // When/Then: 例外がスローされること
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+            mStockService.createStockImpl(secondStock);
+        }, "既に在庫レコードが存在する場合、例外がスローされること");
+        
+        assertTrue(exception.getMessage().contains("既に存在します"), 
+            "エラーメッセージに「既に存在します」が含まれること");
+    }
+
+    @Test
+    @DisplayName("quantityが負の値の場合、例外がスローされること")
+    void testCreateStock_NegativeQuantity() {
+        // Given: テスト商品を作成
+        MProduct product = createTestProduct();
+        
+        // 在庫情報を準備（quantityが負の値）
+        MStock stock = new MStock();
+        stock.setProductId(product.getProductId());
+        stock.setQuantity(-1);
+        stock.setStatus(0);
+
+        // When/Then: 例外がスローされること
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+            mStockService.createStockImpl(stock);
+        }, "quantityが負の値の場合、例外がスローされること");
+        
+        assertTrue(exception.getMessage().contains("在庫数量は0以上の整数である必要があります"), 
+            "エラーメッセージに「在庫数量は0以上の整数である必要があります」が含まれること");
+    }
+
+    @Test
+    @DisplayName("quantityがnullの場合、例外がスローされること")
+    void testCreateStock_NullQuantity() {
+        // Given: テスト商品を作成
+        MProduct product = createTestProduct();
+        
+        // 在庫情報を準備（quantityがnull）
+        MStock stock = new MStock();
+        stock.setProductId(product.getProductId());
+        stock.setQuantity(null);
+        stock.setStatus(0);
+
+        // When/Then: 例外がスローされること
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+            mStockService.createStockImpl(stock);
+        }, "quantityがnullの場合、例外がスローされること");
+        
+        assertTrue(exception.getMessage().contains("在庫数量は0以上の整数である必要があります"), 
+            "エラーメッセージに「在庫数量は0以上の整数である必要があります」が含まれること");
+    }
+
+    @Test
+    @DisplayName("statusが範囲外（負の値）の場合、例外がスローされること")
+    void testCreateStock_InvalidStatusNegative() {
+        // Given: テスト商品を作成
+        MProduct product = createTestProduct();
+        
+        // 在庫情報を準備（statusが負の値）
+        MStock stock = new MStock();
+        stock.setProductId(product.getProductId());
+        stock.setQuantity(100);
+        stock.setStatus(-1);
+
+        // When/Then: 例外がスローされること
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+            mStockService.createStockImpl(stock);
+        }, "statusが範囲外の場合、例外がスローされること");
+        
+        assertTrue(exception.getMessage().contains("在庫ステータスは0（在庫あり）、1（在庫なし）、2（発注済み）のいずれかである必要があります"), 
+            "エラーメッセージに「在庫ステータスは0（在庫あり）、1（在庫なし）、2（発注済み）のいずれかである必要があります」が含まれること");
+    }
+
+    @Test
+    @DisplayName("statusが範囲外（3以上）の場合、例外がスローされること")
+    void testCreateStock_InvalidStatusTooLarge() {
+        // Given: テスト商品を作成
+        MProduct product = createTestProduct();
+        
+        // 在庫情報を準備（statusが3）
+        MStock stock = new MStock();
+        stock.setProductId(product.getProductId());
+        stock.setQuantity(100);
+        stock.setStatus(3);
+
+        // When/Then: 例外がスローされること
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+            mStockService.createStockImpl(stock);
+        }, "statusが範囲外の場合、例外がスローされること");
+        
+        assertTrue(exception.getMessage().contains("在庫ステータスは0（在庫あり）、1（在庫なし）、2（発注済み）のいずれかである必要があります"), 
+            "エラーメッセージに「在庫ステータスは0（在庫あり）、1（在庫なし）、2（発注済み）のいずれかである必要があります」が含まれること");
+    }
+
+    @Test
+    @DisplayName("在庫更新が成功すること")
+    void testUpdateStock_Success() {
+        // Given: テスト商品と在庫を作成
+        MProduct product = createTestProduct();
+        MStock stock = new MStock();
+        stock.setProductId(product.getProductId());
+        stock.setQuantity(100);
+        stock.setStatus(0);
+        mStockService.createStockImpl(stock);
+
+        // 在庫情報を更新
+        stock.setQuantity(200);
+        stock.setStatus(0);
+
+        // When: 在庫を更新
+        boolean result = mStockService.updateStockImpl(stock);
+
+        // Then: 更新が成功すること
+        assertTrue(result, "在庫更新が成功すること");
+        
+        // 更新後の値を確認
+        MStock updatedStock = mStockService.getById(stock.getStockId());
+        assertEquals(200, updatedStock.getQuantity(), "quantityが更新されていること");
+    }
+
+    @Test
+    @DisplayName("在庫IDがnullの場合、例外がスローされること")
+    void testUpdateStock_NullStockId() {
+        // Given: stockIdがnullの在庫情報
+        MStock stock = new MStock();
+        stock.setStockId(null);
+        stock.setQuantity(100);
+
+        // When/Then: 例外がスローされること
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+            mStockService.updateStockImpl(stock);
+        }, "在庫IDがnullの場合、例外がスローされること");
+        
+        assertTrue(exception.getMessage().contains("在庫IDは必須です"), 
+            "エラーメッセージに「在庫IDは必須です」が含まれること");
+    }
+
+    @Test
+    @DisplayName("在庫レコードが存在しない場合、例外がスローされること")
+    void testUpdateStock_StockNotFound() {
+        // Given: 存在しない在庫IDを指定
+        MStock stock = new MStock();
+        stock.setStockId("non-existent-stock-id");
+        stock.setQuantity(100);
+
+        // When/Then: 例外がスローされること
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+            mStockService.updateStockImpl(stock);
+        }, "在庫レコードが存在しない場合、例外がスローされること");
+        
+        assertTrue(exception.getMessage().contains("在庫レコードが存在しません"), 
+            "エラーメッセージに「在庫レコードが存在しません」が含まれること");
+    }
+
+    @Test
+    @DisplayName("在庫削除が成功すること")
+    void testDeleteStock_Success() {
+        // Given: テスト商品と在庫を作成
+        MProduct product = createTestProduct();
+        MStock stock = new MStock();
+        stock.setProductId(product.getProductId());
+        stock.setQuantity(100);
+        stock.setStatus(0);
+        mStockService.createStockImpl(stock);
+        String stockId = stock.getStockId();
+
+        // When: 在庫を削除
+        boolean result = mStockService.deleteStockImpl(stockId);
+
+        // Then: 削除が成功すること
+        assertTrue(result, "在庫削除が成功すること");
+        
+        // 削除後の在庫が取得できないこと（論理削除）
+        MStock deletedStock = mStockService.getById(stockId);
+        assertNull(deletedStock, "削除後の在庫が取得できないこと");
+    }
+
+    @Test
+    @DisplayName("在庫照会が成功すること")
+    void testGetStockByProductId_Success() {
+        // Given: テスト商品と在庫を作成
+        MProduct product = createTestProduct();
+        MStock stock = new MStock();
+        stock.setProductId(product.getProductId());
+        stock.setQuantity(100);
+        stock.setStatus(0);
+        mStockService.createStockImpl(stock);
+
+        // When: 在庫を照会
+        MStock foundStock = mStockService.getStockByProductIdImpl(product.getProductId());
+
+        // Then: 在庫情報が正しく取得できること
+        assertNotNull(foundStock, "在庫情報が取得できること");
+        assertEquals(product.getProductId(), foundStock.getProductId(), "productIdが正しいこと");
+        assertEquals(100, foundStock.getQuantity(), "quantityが正しいこと");
+        assertEquals(0, foundStock.getStatus(), "statusが正しいこと");
+    }
+
+    @Test
+    @DisplayName("商品が存在しない場合、在庫照会で例外がスローされること")
+    void testGetStockByProductId_ProductNotFound() {
+        // When/Then: 例外がスローされること
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+            mStockService.getStockByProductIdImpl("non-existent-product-id");
+        }, "商品が存在しない場合、例外がスローされること");
+        
+        assertTrue(exception.getMessage().contains("商品が存在しません"), 
+            "エラーメッセージに「商品が存在しません」が含まれること");
+    }
+
+    @Test
+    @DisplayName("在庫レコードが存在しない場合、在庫照会で例外がスローされること")
+    void testGetStockByProductId_StockNotFound() {
+        // Given: テスト商品を作成（在庫は登録しない）
+        MProduct product = createTestProduct();
+
+        // When/Then: 例外がスローされること
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+            mStockService.getStockByProductIdImpl(product.getProductId());
+        }, "在庫レコードが存在しない場合、例外がスローされること");
+        
+        assertTrue(exception.getMessage().contains("在庫レコードが存在しません"), 
+            "エラーメッセージに「在庫レコードが存在しません」が含まれること");
+    }
+}


### PR DESCRIPTION
- 在庫管理機能のCRUD操作を実装
  - 在庫登録、更新、削除、検索、照会機能を追加
  - MStockControllerにSwaggerアノテーションを追加
  - MStockServiceImplにVavrを使用した業務ロジックを実装

- Vavrライブラリを追加（業務ロジック用）
  - build.gradleにio.vavr:vavr:0.10.4を追加
  - MStockServiceImplとMUserServiceImplでOptionを使用したnullチェックとバリデーションを実装
  - MyBatis呼び出しは副作用として一括処理

- テストコードの追加
  - MStockServiceImplTest: 16件のテストケース（正常系・異常系）
  - MStockControllerTest: 8件のテストケース（APIエンドポイントのテスト）

- その他の変更
  - MUserServiceImplにVavrを使用した実装を追加