### PR TITLE
Add Prometheus, Grafana, OpenSearch and Actuator config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '4.0.1'
+	id 'org.springframework.boot' version '4.0.2'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -29,7 +29,7 @@ dependencies {
 	// UUID生成ライブラリ
 	implementation 'com.fasterxml.uuid:java-uuid-generator:5.1.0'
 
-	implementation 'org.springframework.boot:spring-boot-starter-jdbc:4.0.1'
+	implementation 'org.springframework.boot:spring-boot-starter-jdbc:4.0.2'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	// MyBatis Plus - Spring Boot 4対応版
 	implementation 'com.baomidou:mybatis-plus-spring-boot4-starter:3.5.15'
@@ -43,6 +43,9 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1'
 	// Vavr
 	implementation 'io.vavr:vavr:0.10.4'
+	// Actuator
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	
 
 	// .envファイル読み込み
 	developmentOnly 'me.paulschwarz:springboot4-dotenv:5.1.0'
@@ -50,6 +53,8 @@ dependencies {
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
 	runtimeOnly 'org.postgresql:postgresql'
+	// Prometheus メトリクス
+	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'com.fasterxml.jackson.core:jackson-databind'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,9 +33,33 @@ services:
     networks:
       - playjava-network
 
+  prometheus:
+    container_name: prometheus
+    image: prom/prometheus:latest
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+    ports:
+      - 9090:9090
+    networks:
+      - playjava-network
+
+  grafana:
+    container_name: grafana
+    image: grafana/grafana:latest
+    ports:
+      - 3000:3000
+    depends_on:
+      - prometheus
+    networks:
+      - playjava-network
+
+
 volumes:
   postgres_data:
   pgadmin_data:
+  opensearch_data:
 
 networks:
   playjava-network:

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: "spring-boot"
+    metrics_path: "/actuator/prometheus"
+    static_configs:
+      - targets:
+          - "host.docker.internal:8080"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,3 +39,17 @@ springdoc:
     operations-sorter: method
     tags-sorter: alpha
   show-actuator: false
+
+# Spring Boot Actuator設定
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus,health,info
+  endpoint:
+    prometheus:
+      enabled: true
+    health:
+      enabled: true
+    info:
+      enabled: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Enables new Actuator endpoints (including Prometheus scrape) which can expose operational data if deployed without proper access controls; otherwise changes are mostly additive dependency and dev-infra updates.
> 
> **Overview**
> Adds *observability support* by upgrading Spring Boot from `4.0.1` to `4.0.2`, adding `spring-boot-starter-actuator`, and enabling Prometheus metrics via `micrometer-registry-prometheus`.
> 
> Introduces Prometheus and Grafana services in `docker-compose.yml` plus a new `prometheus.yml` that scrapes `/actuator/prometheus`, and configures `application.yml` to expose `prometheus`, `health`, and `info` Actuator endpoints over HTTP.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12d52b56511492b6d013995e33826ebd7e5a1b66. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->