### PR TITLE
Add OpenSearch and related config (docker-compose, application.yml, b…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,29 +31,27 @@ dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc:4.0.2'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	// MyBatis Plus - Spring Boot 4対応版
+	// MyBatis Plus
 	implementation 'com.baomidou:mybatis-plus-spring-boot4-starter:3.5.15'
-	// MyBatis Plus - ページングプラグイン用（v3.5.9以降必須）
-	// PaginationInnerInterceptorを使用するために必要
+	// MyBatis Plus
 	implementation 'com.baomidou:mybatis-plus-jsqlparser:3.5.15'
 	implementation 'com.baomidou:mybatis-plus-extension:3.5.15'
 	implementation 'com.baomidou:mybatis-plus-generator:3.5.15'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
-	// SpringDoc OpenAPI (Swagger UI) - 3.x は Spring Boot 4 対応
+	// SpringDoc OpenAPI (Swagger UI)
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1'
 	// Vavr
 	implementation 'io.vavr:vavr:0.10.4'
 	// Actuator
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	
-
 	// .envファイル読み込み
 	developmentOnly 'me.paulschwarz:springboot4-dotenv:5.1.0'
+
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
 	runtimeOnly 'org.postgresql:postgresql'
-	// Prometheus メトリクス
+	// Prometheus
 	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,12 +54,82 @@ services:
       - prometheus
     networks:
       - playjava-network
+    env_file:
+      - .env
 
+  opensearch-node1:
+    image: opensearchproject/opensearch:3.4.0
+    container_name: opensearch-node1
+    environment:
+      - cluster.name=opensearch-cluster
+      - node.name=opensearch-node1
+      - discovery.seed_hosts=opensearch-node1,opensearch-node2
+      - cluster.initial_cluster_manager_nodes=opensearch-node1,opensearch-node2
+      - bootstrap.memory_lock=true
+      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
+      - "DISABLE_INSTALL_DEMO_CONFIG=true"
+      - "DISABLE_SECURITY_PLUGIN=true"
+      - OPENSEARCH_INITAL_ADMIN_PASSWORD=${OPENSEARCH_INITIAL_ADMIN_PASSWORD}
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    volumes:
+      - opensearch_data1:/user/share/opensearch_data
+    ports:
+      - 9200:9200
+      - 9600:9600
+    networks:
+      - playjava-network
+  opensearch-node2:
+    image: opensearchproject/opensearch:3.4.0
+    container_name: opensearch-node2
+    environment:
+      - cluster.name=opensearch-cluster
+      - node.name=opensearch-node2
+      - discovery.seed_hosts=opensearch-node1,opensearch-node2
+      - cluster.initial_cluster_manager_nodes=opensearch-node1,opensearch-node2
+      - bootstrap.memory_lock=true
+      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
+      - "DISABLE_INSTALL_DEMO_CONFIG=true"
+      - "DISABLE_SECURITY_PLUGIN=true"
+      - OPENSEARCH_INITAL_ADMIN_PASSWORD=${OPENSEARCH_INITIAL_ADMIN_PASSWORD}
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    volumes:
+      - opensearch_data2:/user/share/opensearch_data
+    networks:
+      - playjava-network
+    env_file:
+      - .env
+  opensearch-dashboards:
+    image: opensearchproject/opensearch-dashboards:3.4.0
+    container_name: opensearch-dashboards
+    ports:
+      - 5601:5601
+    expose:
+      - "5601"
+    environment:
+      - 'OPENSEARCH_HOSTS=["http://opensearch-node1:9200", "http://opensearch-node2:9200"]'
+      - "DISABLE_SECURITY_DASHBOARDS_PLUGIN=true"
+    networks:
+      - playjava-network
+    env_file:
+      - .env
 
 volumes:
   postgres_data:
   pgadmin_data:
-  opensearch_data:
+  opensearch_data1:
+  opensearch_data2:
 
 networks:
   playjava-network:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,6 +27,7 @@ logging:
     root: DEBUG
     org.apache.ibatis: DEBUG
     com.baomidou.mybatisplus: DEBUG
+    org.springdoc: INFO
 
 # SpringDoc OpenAPI設定
 springdoc:
@@ -53,3 +54,6 @@ management:
       enabled: true
     info:
       enabled: true
+  metrics:
+    tags:
+      application: playjava


### PR DESCRIPTION
…uild.gradle)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Main risk is operational: new docker services/ports/volumes and disabling OpenSearch security plugins for local use can cause misconfiguration or accidental exposure if reused beyond dev.
> 
> **Overview**
> Adds an **OpenSearch local stack** by extending `docker-compose.yml` with two OpenSearch nodes plus `opensearch-dashboards`, new persistent volumes, and `.env` wiring (also applied to `grafana`).
> 
> Updates runtime configuration in `application.yml` by setting `org.springdoc` logging to `INFO` and adding a global Micrometer metric tag (`management.metrics.tags.application=playjava`). `build.gradle` changes are comment-only cleanups around dependency annotations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4330fec510fd5cd81b00738330ee9427686dabef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->